### PR TITLE
total reserved slots v1 added and formFeedBack op discrepency patched

### DIFF
--- a/cogs/autoSlot.py
+++ b/cogs/autoSlot.py
@@ -777,7 +777,7 @@ class autoSlot(commands.Cog):
         del self.database['operations'][operation_id]
         self.saveData()
 
-        await self.FormFeedback.deleteOp(operation_id)
+        await self.FormFeedBack.deleteOp(operation_id)
 
         # Notify user
         await botCommandsChannel.send(f"{ctx.author.mention} removed operation {deletedunit}.")
@@ -819,6 +819,7 @@ class autoSlot(commands.Cog):
                 else:
                     slots = slots + (f"{slot}: {self.database['operations'][operation_id]['groups'][group][slot]} - {ctx.guild.get_member(assignments.get(slot)).mention}\n")
             slot_embed.add_field(name=group, value=slots, inline=False)
+        slot_embed.add_field(name="Total Reservations:", value=len(assignments))
         return slot_embed
 
     # Parse inputted slots into autoSlot format


### PR DESCRIPTION
total reserved slots will now appear at the bottom of rosters, and an issue with formfeedback not having its database corrected when an op is deleted has been patched.